### PR TITLE
Chores/Setup Prisma Postgres DB in Vercel for Production deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 - Create individual event page to view detailed info for the specific event
 - Create `skeleton.tsx` and `skeleton-card.tsx` components to render while the page is loading
 - Create `db.ts` under `lib` folder to use a single instantiation of PrismaClient throughout the entire app
+- Add a `postinstall` lifecycle script to automatically generate `Prisma Client` after installing dependencies
+- Change the database provider from `SQLite` to `Postgres`
 
 ## Notes
 
@@ -30,32 +32,108 @@
     ```
 
   - `Do this` -> Remove each cached file (where you see the tracking issue) from Git index using the command
+
     ```bash
     git rm --cached src/components/Header.tsx
     git rm --cached src/components/H1.tsx
     git rm --cached src/components/Logo.tsx
     ```
+
   - Rename those files manually in kebab case format (previously it was in pascal case)
 
 - Install and Configure Prisma ORM
 
-  ```bash
-  # to install prisma
-  npm i prisma@5.6.0 --save-dev
+  - Install `prisma`, `ts-node` and `@prisma/client` npm packages
 
-  # to configure prisma with sqlite database
-  npx prisma init --datasource-provider sqlite
+    ```bash
+    npm install prisma@5.22.0 ts-node@10.9.1 --save-dev
+    npm install @prisma/client
+    ```
 
-  # to create your tables after defining your models in schema.prisma file
-  npx prisma db push
+  ## `SQLite`
 
-  # to execute the seed command defined under the prisma key in package.json
-  # Source -> https://www.prisma.io/docs/orm/prisma-migrate/workflows/seeding#seeding-your-database-with-typescript-or-javascript
-  npx prisma db seed
+  - Configure prisma with sqlite database
 
-  # to open prisma studio
-  npx prisma studio
-  ```
+    ```bash
+    npx prisma init --datasource-provider sqlite
+    ```
+
+  - Create tables after defining your models in `schema.prisma` file
+
+    ```bash
+    npx prisma db push
+    ```
+
+  ## `PostgreSQL`
+
+  - Configure prisma with default database i.e., postgres. It will create a `schema.prisma` file in the `prisma` folder.
+
+    ```bash
+    npx prisma init
+    ```
+
+  - Create tables after defining your models in `schema.prisma` file
+
+    ```bash
+    npx prisma db push
+    ```
+
+  - Edit the `DATABASE_URL` value in `.env` file for postgres
+
+    ```properties
+    DATABASE_URL="postgresql://<postgres_superuser_name>:<superuser_password>@localhost:<postgres_server_port>/<database_name>?schema=public"
+    ```
+
+    | Key                     | Description                                  |
+    | ----------------------- | -------------------------------------------- |
+    | postgres_superuser_name | Usually it's `postgres` itself               |
+    | superuser_password      | Superuser's password set during installation |
+    | postgres_server_port    | Usually it's `5432` or `5433`                |
+    | database_name           | Your desired database name                   |
+
+    _Note: If you have multiple versions of postgres installed in your pc (let's say v14 and v17). To use the specific one, say v17 (the server where you would want to create your database), go to `C:\Program Files\PostgreSQL\17\installation_summary.log` (in Windows) and look for port info within the log._
+
+    _Note: Remove all angular brackets before saving the contents in `.env` file_
+
+  - Execute the seed command defined under the `prisma` key in `package.json`. [Source](https://www.prisma.io/docs/orm/prisma-migrate/workflows/seeding#seeding-your-database-with-typescript-or-javascript)
+
+    ```bash
+    npx prisma db seed
+    ```
+
+  - Open Prisma Studio to view the seeded data from the database
+
+    ```bash
+    npx prisma studio
+    ```
+
+  - Resources
+    - [How to Build a Fullstack App with Next.js, Prisma, and Postgres](https://vercel.com/guides/nextjs-prisma-postgres)
+    - [How to use Prisma ORM with Next.js](https://www.prisma.io/docs/guides/nextjs#introduction)
+
+- `5433` is the port for `PostgreSQL v17` meanwhile `5432` is the port for `PostgreSQL v14` (it's my personal local configuration)
+
+  - To confirm the port for `PostgreSQL v14`, read the log from `C:\Program Files\PostgreSQL\14\installation_summary.log`
+
+- Setup Prisma Postgres database in Vercel
+
+  - Create a [Prisma Postgres database in Vercel](https://vercel.com/dashboard/stores)
+
+  - Copy the `.env.local` contents of your newly created prisma postgres database, into your local `.env` file
+
+  - Create the tables in your newly created prisma postgres database, defined in your `schema.prisma` file using the following command (from your local bash terminal)
+
+    ```bash
+    npx prisma db push
+    ```
+
+  - Once the tables are created, you can seed your data to your remote prisma postgres database via the following command (given that you have a `seed.ts` file in your `prisma` folder)
+
+    ```bash
+    npx prisma db seed
+    ```
+
+  - Visit [Prisma Console](https://console.prisma.io/) to view the data seeded into your prisma postgres database
 
 - Comment out `TEventoEvent` type from `lib/types.ts` to just have one source of truth and so is being imported from `@prisma/client` when `npx prisma db push` command was executed in terminal to create the `EventoEvent` table
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "evento",
       "version": "0.1.0",
       "dependencies": {
-        "@prisma/client": "^5.6.0",
+        "@prisma/client": "^5.22.0",
         "@radix-ui/react-icons": "^1.3.2",
         "clsx": "^2.1.1",
         "framer-motion": "^10.16.4",
@@ -24,7 +24,7 @@
         "eslint": "^8",
         "eslint-config-next": "15.0.3",
         "postcss": "^8",
-        "prisma": "^5.6.0",
+        "prisma": "^5.22.0",
         "tailwindcss": "^3.4.1",
         "ts-node": "^10.9.1",
         "typescript": "^5",
@@ -1086,14 +1086,11 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.6.0.tgz",
-      "integrity": "sha512-mUDefQFa1wWqk4+JhKPYq8BdVoFk9NFMBXUI8jAkBfQTtgx8WPx02U2HB/XbAz3GSUJpeJOKJQtNvaAIDs6sug==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.22.0.tgz",
+      "integrity": "sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/engines-version": "5.6.0-32.e95e739751f42d8ca026f6b910f5a2dc5adeaeee"
-      },
       "engines": {
         "node": ">=16.13"
       },
@@ -1106,19 +1103,62 @@
         }
       }
     },
-    "node_modules/@prisma/engines": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.6.0.tgz",
-      "integrity": "sha512-Mt2q+GNJpU2vFn6kif24oRSBQv1KOkYaterQsi0k2/lA+dLvhRX6Lm26gon6PYHwUM8/h8KRgXIUMU0PCLB6bw==",
+    "node_modules/@prisma/debug": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
+      "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==",
       "devOptional": true,
-      "hasInstallScript": true,
       "license": "Apache-2.0"
     },
-    "node_modules/@prisma/engines-version": {
-      "version": "5.6.0-32.e95e739751f42d8ca026f6b910f5a2dc5adeaeee",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.6.0-32.e95e739751f42d8ca026f6b910f5a2dc5adeaeee.tgz",
-      "integrity": "sha512-UoFgbV1awGL/3wXuUK3GDaX2SolqczeeJ5b4FVec9tzeGbSWJboPSbT0psSrmgYAKiKnkOPFSLlH6+b+IyOwAw==",
+    "node_modules/@prisma/engines": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
+      "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0",
+        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+        "@prisma/fetch-engine": "5.22.0",
+        "@prisma/get-platform": "5.22.0"
+      }
+    },
+    "node_modules/@prisma/engines/node_modules/@prisma/engines-version": {
+      "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
+      "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
+      "devOptional": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
+      "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0",
+        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+        "@prisma/get-platform": "5.22.0"
+      }
+    },
+    "node_modules/@prisma/fetch-engine/node_modules/@prisma/engines-version": {
+      "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
+      "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
+      "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0"
+      }
     },
     "node_modules/@radix-ui/react-icons": {
       "version": "1.3.2",
@@ -6501,20 +6541,23 @@
       }
     },
     "node_modules/prisma": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.6.0.tgz",
-      "integrity": "sha512-EEaccku4ZGshdr2cthYHhf7iyvCcXqwJDvnoQRAJg5ge2Tzpv0e2BaMCp+CbbDUwoVTzwgOap9Zp+d4jFa2O9A==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
+      "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/engines": "5.6.0"
+        "@prisma/engines": "5.22.0"
       },
       "bin": {
         "prisma": "build/index.js"
       },
       "engines": {
         "node": ">=16.13"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
       }
     },
     "node_modules/promisepipe": {

--- a/package.json
+++ b/package.json
@@ -6,13 +6,14 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "prisma generate"
   },
   "prisma": {
     "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"
   },
   "dependencies": {
-    "@prisma/client": "^5.6.0",
+    "@prisma/client": "^5.22.0",
     "@radix-ui/react-icons": "^1.3.2",
     "clsx": "^2.1.1",
     "framer-motion": "^10.16.4",
@@ -28,7 +29,7 @@
     "eslint": "^8",
     "eslint-config-next": "15.0.3",
     "postcss": "^8",
-    "prisma": "^5.6.0",
+    "prisma": "^5.22.0",
     "tailwindcss": "^3.4.1",
     "ts-node": "^10.9.1",
     "typescript": "^5",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,12 +1,15 @@
 // This is your Prisma schema file,
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
+// Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?
+// Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
+
 generator client {
   provider = "prisma-client-js"
 }
 
 datasource db {
-  provider = "sqlite"
+  provider = "postgresql"
   url      = env("DATABASE_URL")
 }
 


### PR DESCRIPTION
## Tasks Done —>
- Add a `postinstall` lifecycle script to automatically generate `Prisma Client` after installing dependencies
- Change the database provider from `SQLite` to `Postgres`
- Document the process of installing and configuring `Prisma ORM` and `Postgres` database for `local` as well as for `Vercel`